### PR TITLE
Upgrades xbean-reflect library which leaked log4j

### DIFF
--- a/plexus-component-javadoc/pom.xml
+++ b/plexus-component-javadoc/pom.xml
@@ -19,11 +19,29 @@
 
   <profiles>
     <profile>
-      <id>default-tools.jar</id>
+      <id>default-tools.jar-sun</id>
       <activation>
         <property>
           <name>java.vendor</name>
           <value>Sun Microsystems Inc.</value>
+        </property>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>com.sun</groupId>
+          <artifactId>tools</artifactId>
+          <version>1.4.2</version>
+          <scope>system</scope>
+          <systemPath>${java.home}/../lib/tools.jar</systemPath>
+        </dependency>
+      </dependencies>
+    </profile>
+    <profile>
+      <id>default-tools.jar-oracle</id>
+      <activation>
+        <property>
+          <name>java.vendor</name>
+          <value>Oracle Corporation</value>
         </property>
       </activation>
       <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
   <properties>
     <classWorldsVersion>2.2.2</classWorldsVersion>
     <plexusUtilsVersion>1.4.5</plexusUtilsVersion>
-    <xbeanReflectVersion>3.4</xbeanReflectVersion>
+    <xbeanReflectVersion>3.11.1</xbeanReflectVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 


### PR DESCRIPTION
Before this fix a version of xbean-reflect library was used which
leaked log4j logging library implementation.

Also, building project on Oracle Java SE 7 would fail to compile
javadoc module which requires JDK tools.jar, as there was no profile
configured to provide the tools.jar activated for the new java vendor.

Issue: PLX-465
